### PR TITLE
Adjusted wording of /crowd command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,8 @@ fn main() {
                       },
                       "/crowd" => {
                         let s = match fetch_people_now_present() {
-                          Ok(people_now_present) if people_now_present > 0 => format!("{} are inhouse", people_now_present),
-                          Ok(_) => format!("Coredump is empty."),
+                          Ok(people_now_present) if people_now_present > 0 => format!("{} people are present!", people_now_present),
+                          Ok(_) => format!("Nobody here right now."),
                           Err(e) => format!("An error occured 😕\n{}", e),
                         };
                         try!(api.send_message(


### PR DESCRIPTION
What do you think about this?
- Coredump is not really empty when nobody is there :)
- "Inhouse" is more about employees belonging to a company or being employed externally.
