### PR TITLE
implement exponential Backoff

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
         });
 
         if let Err(e) = res {
-            println!("An error occured: {}\nresting {} Seconds", e, backoff_seconds);
+            println!("An error occured: {}\nRemaining {} Seconds", e, backoff_seconds);
             // Rest for 10 Seconds
             std::thread::sleep_ms(backoff_seconds * 1000);
             

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
         });
 
         if let Err(e) = res {
-            println!("An error occured: {}\nRemaining {} Seconds", e, backoff_seconds);
+            println!("An error occured: {}\nSleeping for {} Seconds", e, backoff_seconds);
             // Rest for 10 Seconds
             std::thread::sleep_ms(backoff_seconds * 1000);
             


### PR DESCRIPTION
To ease the load on Telegram. Logs indicate a ~3 Minute disconnect.

```
An error occured: failed to lookup address information: Name or service not known
getMe: Err(Http(Io(Error { repr: Custom(Custom { kind: Other, error: StringError("failed to lookup address information: Name or service not known") }) })))
```
