### PR TITLE
Change /crowd to /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Every Message starts with one of the following words:
 
 ## [Unreleased]
 
+ - Remove /crowd
+ - Add temperatures and status text to /status
+
 ## [0.2.8] - 2016-05-13
 
  - Add /location

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -46,6 +46,6 @@ mod test {
     println!("alles: {:?}", g);
     // TODO real Test
     assert!(g.is_empty() == false);
-    //assert!("\n\n".is_suffix_of(g));
+    assert_eq!(format!(":= *\n\n"), g[(g.len()-6)..]);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
                             );
                         },
                         Input::Status => {
-                            let s = match sac.fetch_people_now_present() {
+                            let s = match sac.fetch_aggregated_status() {
                                 Ok(people_now_present) => people_now_present,
                                 Err(e) => format!("An error occured 😕\n{}", e),
                             };

--- a/src/user_input_compiler.rs
+++ b/src/user_input_compiler.rs
@@ -4,7 +4,7 @@
 //! 
 //! Command         := "/" CommandWord
 //! CommandWord     := Status | Subscribe | Cancel | Version | Help | WebCam | Start | Grammar | Location | InvalidSyntax
-//! Status          := "status" | "crowd"
+//! Status          := "status"
 //! Subscribe       := "subscribe" SensorSelector Duration
 //! SensorSelector  := SensorString OptionalInteger
 //! SensorString    := "account_balance" | "barometer" | "beverage_supply" | "door_locked" | "humidity" | "network_connections" | "power_consumption" | "temperature" | "total_member_count" | "radiation.alpha" | "radiation.beta_gamma" | "radiation.beta" | "radiation.gamma" | "people_now_present" | "wind"
@@ -78,7 +78,7 @@ impl From<String> for Input {
 }
 
 fn match_command_word(s :&mut Chars) -> Input {
-  if starts_with(s, "status") || starts_with(s, "crowd") {
+  if starts_with(s, "status") {
     return Status;
   } else
   if matches_with(s, "subscribe") {
@@ -442,8 +442,8 @@ mod test {
   }
   
   #[test]
-  fn crowd() {
-    assert_eq!(Status, Input::from( format!("/crowd") ) )
+  fn crowd() { // cancelled with 0.3.0
+    assert_eq!(InvalidSyntax("Invalid CommandWord".into()), Input::from( format!("/crowd") ) )
   }
   
   #[test]


### PR DESCRIPTION
I'd change the /crowd command to /status.

That object would return all variable data from the sensors. We could also call it /sensors, but /status probably makes more sense.
- Open yes/no
- People present
- Temperature

Once we add more information, the status becomes more interesting.

After all, it doesn't take longer (maybe a few ms), doesn't need an additional request and improves the usefulness of the command.

What do you think, @dns2utf8?
